### PR TITLE
Update lecture_7_preparing_basis_states.ipynb

### DIFF
--- a/lecture_7_preparing_basis_states.ipynb
+++ b/lecture_7_preparing_basis_states.ipynb
@@ -446,7 +446,7 @@
     "\\begin{align}\n",
     "\\begin{pmatrix} 1\\\\0 \\end{pmatrix} \\otimes\n",
     "\\begin{pmatrix} 1\\\\0 \\end{pmatrix} \\otimes\n",
-    "\\begin{pmatrix} 0\\\\1 \\end{pmatrix}\n",
+    "\\begin{pmatrix} 1\\\\0 \\end{pmatrix}\n",
     "\\end{align}"
    ]
   },


### PR DESCRIPTION
The state A =  |0> = [1,0], then |0 0 0 > is the np.kron(A,np.kron(A,A)), the notebook the line 449 says  the first calculation should be:
  "\\begin{pmatrix} 1\\\\0 \\end{pmatrix} \\otimes\n",
    "\\begin{pmatrix} 1\\\\0 \\end{pmatrix} \\otimes\n",
    "\\begin{pmatrix} 0\\\\1 \\end{pmatrix}\n", 
that is the update I am proposing. Note the last line is wrong, if I understood correctly what you are saying. It should be 
\\begin{pmatrix} 1\\\\0 \\end{pmatrix}\n",